### PR TITLE
Update golangci linter to v1.21.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dependencies:
     # install ginkgo
 	GOBIN=$(BINDIR) go install ./vendor/github.com/onsi/ginkgo/ginkgo
 	# install golangci-lint
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINARY=golangci-lint bash -s -- -b $(BINDIR) v1.16.0
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINARY=golangci-lint bash -s -- -b $(BINDIR) v1.21.0
 	# install yq
 	curl -sfL https://github.com/mikefarah/yq/releases/download/2.1.1/yq_$(OS)_$(ARCH) -o $(BINDIR)/yq
 	chmod +x $(BINDIR)/yq


### PR DESCRIPTION
This is needed in order for golangci-linter to work with go 1.13.