### PR TITLE
Bumped nginx-ingress and cert-manager

### DIFF
--- a/charts/stack/requirements.lock
+++ b/charts/stack/requirements.lock
@@ -7,15 +7,15 @@ dependencies:
   version: v0.8.2
 - name: nginx-ingress
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.30.0
+  version: 1.31.0
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v0.13.0
+  version: v0.13.1
 - name: prometheus-operator
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 8.7.0
 - name: git-webhook
   repository: file://../git-webhook
   version: 0.0.1+master
-digest: sha256:61f4e86c38ab12ead1b2200a62b919743e26a7aae1480afa6670c541e0a9cfd0
-generated: "2020-02-10T16:51:40.890771+02:00"
+digest: sha256:e8fe4123e93b1019206934d3c91018eac17ca0f7d2840952b1f781513f79cdb0
+generated: 2020-02-24T11:13:34.895789216+02:00

--- a/charts/stack/requirements.yaml
+++ b/charts/stack/requirements.yaml
@@ -11,7 +11,7 @@ dependencies:
 
   - name: nginx-ingress
     repository: https://kubernetes-charts.storage.googleapis.com/
-    version: ~1.30.0
+    version: ~1.31.0
     condition: nginx-ingress.enabled
 
   - name: cert-manager

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -4225,7 +4225,6 @@ spec:
                   type: object
                   required:
                   - apiTokenSecretRef
-                  - url
                   properties:
                     apiTokenSecretRef:
                       description: APITokenSecretRef is a secret key selector for
@@ -5965,7 +5964,6 @@ spec:
                   type: object
                   required:
                   - apiTokenSecretRef
-                  - url
                   properties:
                     apiTokenSecretRef:
                       description: APITokenSecretRef is a secret key selector for


### PR DESCRIPTION
Bumped nginx-ingress to v0.29. This should fix the Ingress LoadBalancer IP status not being updated.

Cert-manager had a collateral patch version bump, when running `helm dependency update`.